### PR TITLE
Fix entrytimeissue

### DIFF
--- a/src/conditioning.cc
+++ b/src/conditioning.cc
@@ -166,14 +166,13 @@ typedef std::map<std::string, std::map<std::string, int>> package_;
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add package state variable, how to use fancy typedef 
   while (processing.count() >= pack_size) {
-    if (pack_size <= processing.count()) {
       // try a for loop 
-      cyclus::PackagedMaterial::matstream temp_stream;
-      double assem_quantity = 0; 
-      for (int a = 1; a = pack_size; a = a + 1) {
-        // pop a bunch of assemblies from processing to our temp stream 
-        temp_stream.push_back(processing.Pop());
-        assem_quantity += (processing.Peek()->quantity());
+    cyclus::PackagedMaterial::matstream temp_stream;
+    double assem_quantity = 0; 
+    for (int a = 1; a = pack_size; a = a + 1) {
+      // pop a bunch of assemblies from processing to our temp stream 
+      temp_stream.push_back(processing.Pop());
+      assem_quantity += (processing.Peek()->quantity());
 	// pop all entry times except the youngest material object 
 	if (a = pack_size) {
 	  pm_entry_times.push_back(context()->time());
@@ -188,7 +187,7 @@ void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add p
     pm = cyclus::PackagedMaterial::Create(this, assem_quantity,temp_package);
     // add packagedmaterial into packaged resbuf 
     packaged.Push(pm);
-  } 
+
   }
   std::cout << "packaged" << std::endl;
 }

--- a/src/conditioning.cc
+++ b/src/conditioning.cc
@@ -176,10 +176,8 @@ void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add p
         assem_quantity += (processing.Peek()->quantity());
 	// pop all entry times except the youngest material object 
 	if (a = pack_size) {
-	  pm_entry_times.push_back(entry_times.pop_front());
-	} else {
-	entry_times.pop_front();
-	}
+	  pm_entry_times.push_back(context()->time());
+	} 
       }
     // place that temp stream into our package_prop 
     cyclus::PackagedMaterial::package temp_package (temp_stream,package_prop);

--- a/src/conditioning.cc
+++ b/src/conditioning.cc
@@ -130,8 +130,6 @@ void Conditioning::Tick() {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conditioning::Tock() {
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is tocking {";
-  std::cout <<  "time" << std::endl;
-  std::cout <<  context()->time() << std::endl;
   BeginProcessing_();  // place unprocessed inventory into processing
   PackageMatl_(package_size,package_properties);
 
@@ -166,17 +164,11 @@ typedef std::map<std::string, std::map<std::string, int>> package_;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add package state variable, how to use fancy typedef 
-  std::cout <<  "processing.count()" << std::endl;
-  std::cout <<  processing.count() << std::endl;
-  std::cout <<  "pack size" << std::endl;
-  std::cout <<  pack_size << std::endl;
   while (processing.count() > pack_size) {
       // try a for loop 
     cyclus::PackagedMaterial::matstream temp_stream;
     double assem_quantity = 0; 
     for (int a = 1; a <= pack_size; a = a + 1) {
-      std::cout <<  "a" << std::endl;
-      std::cout <<  a  << std::endl;
       // pop a bunch of assemblies from processing to our temp stream
       assem_quantity += (processing.Peek()->quantity()); 
       temp_stream.push_back(processing.Pop());

--- a/src/conditioning.cc
+++ b/src/conditioning.cc
@@ -130,7 +130,8 @@ void Conditioning::Tick() {
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conditioning::Tock() {
   LOG(cyclus::LEV_INFO3, "ComCnv") << prototype() << " is tocking {";
-
+  std::cout <<  "time" << std::endl;
+  std::cout <<  context()->time() << std::endl;
   BeginProcessing_();  // place unprocessed inventory into processing
   PackageMatl_(package_size,package_properties);
 
@@ -139,7 +140,7 @@ void Conditioning::Tock() {
   }
 
   ProcessMat_(throughput);  // place ready into stocks
-
+  std::cout << "tocked" << std::endl;
   LOG(cyclus::LEV_INFO3, "ComCnv") << "}";
 }
 
@@ -165,14 +166,20 @@ typedef std::map<std::string, std::map<std::string, int>> package_;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add package state variable, how to use fancy typedef 
-  while (processing.count() >= pack_size) {
+  std::cout <<  "processing.count()" << std::endl;
+  std::cout <<  processing.count() << std::endl;
+  std::cout <<  "pack size" << std::endl;
+  std::cout <<  pack_size << std::endl;
+  while (processing.count() > pack_size) {
       // try a for loop 
     cyclus::PackagedMaterial::matstream temp_stream;
     double assem_quantity = 0; 
-    for (int a = 1; a = pack_size; a = a + 1) {
-      // pop a bunch of assemblies from processing to our temp stream 
+    for (int a = 1; a <= pack_size; a = a + 1) {
+      std::cout <<  "a" << std::endl;
+      std::cout <<  a  << std::endl;
+      // pop a bunch of assemblies from processing to our temp stream
+      assem_quantity += (processing.Peek()->quantity()); 
       temp_stream.push_back(processing.Pop());
-      assem_quantity += (processing.Peek()->quantity());
 	// pop all entry times except the youngest material object 
 	if (a = pack_size) {
 	  pm_entry_times.push_back(context()->time());

--- a/src/conditioning.cc
+++ b/src/conditioning.cc
@@ -174,6 +174,12 @@ void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add p
         // pop a bunch of assemblies from processing to our temp stream 
         temp_stream.push_back(processing.Pop());
         assem_quantity += (processing.Peek()->quantity());
+	// pop all entry times except the youngest material object 
+	if (a = pack_size) {
+	  pm_entry_times.push_back(entry_times.pop_front());
+	} else {
+	entry_times.pop_front();
+	}
       }
     // place that temp stream into our package_prop 
     cyclus::PackagedMaterial::package temp_package (temp_stream,package_prop);
@@ -195,8 +201,8 @@ void Conditioning::ReadyMatl_(int time) {
 
   int to_ready = 0;
 
-  while (!entry_times.empty() && entry_times.front() <= time) {
-    entry_times.pop_front();
+  while (!pm_entry_times.empty() && pm_entry_times.front() <= time) {
+    pm_entry_times.pop_front();
     ++to_ready;
   }
 

--- a/src/conditioning.cc
+++ b/src/conditioning.cc
@@ -165,7 +165,7 @@ typedef std::map<std::string, std::map<std::string, int>> package_;
 
 //- - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - - -
 void Conditioning::PackageMatl_(int pack_size, package_ package_prop) { // add package state variable, how to use fancy typedef 
-  while (processing.count() > pack_size) {
+  while (processing.count() >= pack_size) {
     if (pack_size <= processing.count()) {
       // try a for loop 
       cyclus::PackagedMaterial::matstream temp_stream;

--- a/src/conditioning.h
+++ b/src/conditioning.h
@@ -215,6 +215,11 @@ class Conditioning
                       "internal": True}
   std::list<int> entry_times;
 
+  //// list of input times for youngest material in a packagedmaterial
+  #pragma cyclus var{"default": [],\
+                      "internal": True}
+  std::list<int> pm_entry_times;
+
   #pragma cyclus var {"tooltip":"Buffer for material still waiting for required residence_time"}
   cyclus::toolkit::ResBuf<cyclus::Material> processing;
 


### PR DESCRIPTION
This PR addresses https://github.com/arfc/cyder/issues/32. It fixes that issue. However, there is a new error at the end that is:
```
terminate called after throwing an instance of 'cyclus::ValueError'
  what():  unsupported backend type St4pairISt6vectorIN5boost10shared_ptrIN6cyclus8MaterialEEESaIS5_EESt3mapISsS8_ISsiSt4lessISsESaIS_IKSsiEEESA_SaIS_ISB_SE_EEEE
```